### PR TITLE
Add support to interface for requesting interpreter modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Charms that wish to register a notebook with Zeppelin should `require` this
 interface.  The interface layer will set the following state when appropriate:
 
   * `{relation_name}.joined` indicates that Apache Zeppelin is present,
-    and thus a notebook can be registered with the `register_notebook` method.
+    and thus a notebook can be registered with the `register_notebook` method,
+    or interpreter properties can be modified.
 
   * `{relation_name}.notebook.accepted` indicates that Apache Zeppelin has
     accepted one or more of the requested notebooks.  You can get a list of
@@ -22,8 +23,19 @@ interface.  The interface layer will set the following state when appropriate:
     rejected one or more of the requested notebooks.  You can get a list of
     the rejected notebook filenames with the `rejected_notebooks` method.
 
+  * `{relation_name}.interpreter.changes.accepted` indicates that Apache Zeppelin
+    has accepted one or more of the requested interpreter property changes.  You
+    can get a list of the accepted changes with the `accepted_interpreter_changes` method.
+
+  * `{relation_name}.interpreter.changes.rejected` indicates that Apache Zeppelin has
+    rejected one or more of the requested interpreter property changes.  You can get
+    a list of the rejected changes with the `rejected_interpreter_changes` method.
+
 The `register_notebook` method can be passed either a `filename` or a `contents`
 string.
+
+The `modify_interpreter` method must be passed the name of the interpreter (group) to
+modify, as well as a dict mapping property names to values.
 
 An example of how a charm would use this interface would be:
 
@@ -53,6 +65,12 @@ set the following states when appropriate:
     disconnected and so its notebooks should be removed.  The charm would
     then use the `unremoved_notebooks` method to iterate over the notebooks
     to be removed and call `remove_notebook` to acknowledge them.
+
+  * `{relation_name}.interpreter.change` indicates that a client has
+    requested changes to interpreter properties.  The charm would then
+    iterate over the `interpreter_changes` method, handle them, and use
+    either `accept_interpreter_change` or `reject_interpreter_change`
+    methods to acknowledge them.
 
 An example of how the Zeppelin charm would use this interface would be:
 

--- a/provides.py
+++ b/provides.py
@@ -123,10 +123,8 @@ class ZeppelinProvides(RelationBase):
         """
         Returns a list containing all of the pending interpreter change requests.
 
-        Each change request will be a dict with the keys: name, properties,
-        options, and interpreter_group.  Both properties and options will be
-        dicts mapping keys to values, and interpreter_group will be a list
-        containing dicts with name and class items.
+        Each change request will be a dict with the keys: name, properties.
+        The properties will be a dict mapping keys to values.
         """
         changes = []
         for conv in self.conversations():
@@ -136,8 +134,6 @@ class ZeppelinProvides(RelationBase):
                 changes.append({
                     'name': change['name'],
                     'properties': change.get('properties') or {},
-                    'options': change.get('options') or {},
-                    'interpreter_group': change.get('interpreter_group') or [],
                 })
         return changes
 

--- a/provides.py
+++ b/provides.py
@@ -24,13 +24,19 @@ class ZeppelinProvides(RelationBase):
     @hook('{provides:zeppelin}-relation-changed')
     def changed(self):
         conv = self.conversation()
-        requested = set(json.loads(conv.get_remote('requested-notebooks',
-                                                   '[]')))
+        requested = set(json.loads(conv.get_remote('requested-notebooks', '[]')))
         registered = set(conv.get_local('registered-notebooks', []))
         unregistered = requested - registered
         if unregistered:
             conv.set_local('unregistered-notebooks', list(unregistered))
             conv.set_state('{relation_name}.notebook.registered')
+
+        changes = set(json.loads(conv.get_remote('requested-interpreter-changes', '[]')))
+        processed = set(conv.get_local('processed-interpreter-changes', []))
+        pending = changes - processed
+        if unregistered:
+            conv.set_local('pending-interpreter-changes', list(pending))
+            conv.set_state('{relation_name}.interpreter.change')
 
     @hook('{provides:zeppelin}-relation-departed')
     def departed(self):
@@ -81,6 +87,8 @@ class ZeppelinProvides(RelationBase):
 
                 unregistered.discard(notebook_md5)
                 conv.set_local('unregistered-notebooks', list(unregistered))
+                if not unregistered:
+                    conv.remove_state('{relation_name}.notebook.registered')
 
     def reject_notebook(self, notebook):
         """
@@ -98,6 +106,8 @@ class ZeppelinProvides(RelationBase):
 
                 unregistered.discard(notebook_md5)
                 conv.set_local('unregistered-notebooks', list(unregistered))
+                if not unregistered:
+                    conv.remove_state('{relation_name}.notebook.registered')
 
     def remove_notebook(self, notebook):
         """
@@ -108,3 +118,63 @@ class ZeppelinProvides(RelationBase):
             registered = set(conv.get_local('registered-notebooks', []))
             registered.discard(notebook_md5)
             conv.set_local('registered-notebooks', list(registered))
+
+    def interpreter_changes(self):
+        """
+        Returns a list containing all of the pending interpreter change requests.
+
+        Each change request will be a dict with the keys: name, properties,
+        options, and interpreter_group.  Both properties and options will be
+        dicts mapping keys to values, and interpreter_group will be a list
+        containing dicts with name and class items.
+        """
+        changes = []
+        for conv in self.conversations():
+            batch = conv.get_local('pending-interpreter-changes', [])
+            for change_id in batch:
+                change = json.loads(conv.get_remote('interpreter-change-{}'.format(change_id)))
+                changes.append({
+                    'name': change['name'],
+                    'properties': change.get('properties') or {},
+                    'options': change.get('options') or {},
+                    'interpreter_group': change.get('interpreter_group') or [],
+                })
+        return changes
+
+    def accept_interpreter_change(self, change):
+        """
+        Acknowledge that the given pending interpreter change has been processed.
+        """
+        change_md5 = hashlib.md5(json.dumps(change).encode('utf8')).hexdigest()
+        for conv in self.conversations():
+            processed = set(conv.get_local('processed-interpreter-changes', []))
+            pending = set(conv.get_local('pending-interpreter-changes', []))
+            if change_md5 in pending:
+                processed.add(change_md5)
+                conv.set_local('processed-interpreter-changes', list(registered))
+                conv.set_remote('accepted-interpreter-changes',
+                                json.dumps(list(processed)))
+
+                pending.discard(change_md5)
+                conv.set_local('pending-interpreter-changes', list(pending))
+                if not pending:
+                    conv.remove_state('{relation_name}.interpreter.change')
+
+    def reject_interpreter_change(self, change):
+        """
+        Inform the client that the given pending interpreter change has been rejected.
+        """
+        change_md5 = hashlib.md5(json.dumps(change).encode('utf8')).hexdigest()
+        for conv in self.conversations():
+            rejected = set(conv.get_local('rejected-interpreter-changes', []))
+            pending = set(conv.get_local('pending-interpreter-changes', []))
+            if change_md5 in unregistered:
+                rejected.add(change_md5)
+                conv.set_local('rejected-interpreter-changes', list(rejected))
+                conv.set_remote('rejected-interpreter-changes',
+                                json.dumps(list(rejected)))
+
+                pending.discard(change_md5)
+                conv.set_local('pending-interpreter-changes', list(unregistered))
+                if not pending:
+                    conv.remove_state('{relation_name}.interpreter.change')

--- a/requires.py
+++ b/requires.py
@@ -27,10 +27,15 @@ class ZeppelinRequires(RelationBase):
 
     @hook('{requires:zeppelin}-relation-changed')
     def changed(self):
-        accepted = json.loads(self.get_remote('accepted-notebooks', '[]'))
-        rejected = json.loads(self.get_remote('rejected-notebooks', '[]'))
-        self.toggle_state('{relation_name}.notebook.accepted', bool(accepted))
-        self.toggle_state('{relation_name}.notebook.rejected', bool(rejected))
+        accepted_notebooks = json.loads(self.get_remote('accepted-notebooks', '[]'))
+        rejected_notebooks = json.loads(self.get_remote('rejected-notebooks', '[]'))
+        self.toggle_state('{relation_name}.notebook.accepted', bool(accepted_notebooks))
+        self.toggle_state('{relation_name}.notebook.rejected', bool(rejected_notebooks))
+
+        accepted_changes = json.loads(self.get_remote('accepted-interpreter-changes', '[]'))
+        rejected_changes = json.loads(self.get_remote('rejected-interpreter-changes', '[]'))
+        self.toggle_state('{relation_name}.interpreter.changes.accepted', bool(accepted_changes))
+        self.toggle_state('{relation_name}.interpreter.changes.rejected', bool(rejected_changes))
 
     @hook('{requires:zeppelin}-relation-departed')
     def departed(self):
@@ -71,4 +76,55 @@ class ZeppelinRequires(RelationBase):
         """
         requested = self.get_local('requested-notebooks', {})
         rejected = json.loads(self.get_remote('rejected-notebooks', '[]'))
+        return [v for k, v in requested.items() if k in rejected]
+
+    def modify_interpreter(self, interpreter_name,
+                           properties=None, options=None, interpreter_group=None):
+        """
+        Request a modification of an interpreter.
+
+        :param str interpreter_name: The name of the interpreter to modify.
+        :param dict properties: Optional mapping of new properties to add, or
+            existing properties to modify.  Existing properties that aren't
+            mentioned will be left unchanged.
+        :param dict options: Optional mapping of new options to add, or
+            existing options to modify.  Existing options that aren't
+            mentioned will be left unchanged.
+        :param list interpreter_group: Optional list of interpreters to add to
+            the group or to modify.  Each item of the list should be a dict
+            with two keys, both of which should have string values: `name`
+            and `class`.  If an interpreter with that name is already present
+            in the group, it will be updated.  Otherwise, a new interpreter
+            will be added to the group.
+        """
+        change = {
+            'name': interpreter_name,
+            'properties': properties or {},
+            'options': options or {},
+            'interpreter_group': interpreter_group or [],
+        }
+        change_json = json.dumps(change)
+        change_md5 = hashlib.md5(change_json.encode('utf8')).hexdigest()
+        requested = self.get_local('requested-interpreter-changes', {})
+        requested[change_md5] = change
+        self.set_local('requested-interpreter-changes', requested)
+        self.set_remote(data={
+            'requested-interpreter-changes': json.dumps(list(requested.keys())),
+            'interpreter-change-{}'.format(change_md5): change_json,
+        })
+
+    def accepted_interpreter_changes(self):
+        """
+        Return a list of all interpreter changes that were accepted by Zeppelin.
+        """
+        requested = self.get_local('requested-interpreter-changes', {})
+        accepted = json.loads(self.get_remote('accepted-interpreter-changes', '[]'))
+        return [v for k, v in requested.items() if k in accepted]
+
+    def rejected_interpreter_changes(self):
+        """
+        Return a list of all interpreter changes that were rejected by Zeppelin.
+        """
+        requested = self.get_local('requested-interpreter-changes', {})
+        rejected = json.loads(self.get_remote('rejected-interpreter-changes', '[]'))
         return [v for k, v in requested.items() if k in rejected]

--- a/requires.py
+++ b/requires.py
@@ -78,30 +78,18 @@ class ZeppelinRequires(RelationBase):
         rejected = json.loads(self.get_remote('rejected-notebooks', '[]'))
         return [v for k, v in requested.items() if k in rejected]
 
-    def modify_interpreter(self, interpreter_name,
-                           properties=None, options=None, interpreter_group=None):
+    def modify_interpreter(self, interpreter_name, properties):
         """
         Request a modification of an interpreter.
 
         :param str interpreter_name: The name of the interpreter to modify.
-        :param dict properties: Optional mapping of new properties to add, or
+        :param dict properties: Mapping of new properties to add, or
             existing properties to modify.  Existing properties that aren't
             mentioned will be left unchanged.
-        :param dict options: Optional mapping of new options to add, or
-            existing options to modify.  Existing options that aren't
-            mentioned will be left unchanged.
-        :param list interpreter_group: Optional list of interpreters to add to
-            the group or to modify.  Each item of the list should be a dict
-            with two keys, both of which should have string values: `name`
-            and `class`.  If an interpreter with that name is already present
-            in the group, it will be updated.  Otherwise, a new interpreter
-            will be added to the group.
         """
         change = {
             'name': interpreter_name,
             'properties': properties or {},
-            'options': options or {},
-            'interpreter_group': interpreter_group or [],
         }
         change_json = json.dumps(change)
         change_md5 = hashlib.md5(change_json.encode('utf8')).hexdigest()


### PR DESCRIPTION
To address juju-solutions/charm-insightedge-core#3

It seems that the `interpreterGroup` changes are ignored, and those are defined by the classes and not config.
